### PR TITLE
Fix to remove troublesome regex shortcut

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,18 +5,14 @@ import { transformAsync } from "@babel/core";
 import solid from "babel-preset-solid";
 import ts from "@babel/preset-typescript";
 
-const JSX_RE = /<.+?>/gim;
-
 export function solidPlugin(): Plugin {
   return {
     name: "esbuild:solid",
 
     setup(build) {
-      build.onLoad({ filter: /\.(t|j)sx?$/ }, async (args) => {
+      build.onLoad({ filter: /\.(t|j)sx$/ }, async (args) => {
         const source = await readFile(args.path, { encoding: "utf-8" });
-        const isJsx = JSX_RE.test(source);
 
-        if (!isJsx) return { contents: source, loader: "ts" };
         const { name, ext } = parse(args.path);
         const filename = name + ext;
 


### PR DESCRIPTION
All .tsx and .jsx files will now be transformed.  Previously there was a shortcut regex to test if the file contained JSX but this was not working properly.  Fixes issue #2