### PR TITLE
Add support for hydratable and ssr mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
   "dependencies": {
     "@babel/core": "^7.15.0",
     "@babel/preset-typescript": "^7.15.0",
-    "babel-preset-solid": "^1.1.1",
-    "esbuild": "^0.12.24",
-    "solid-js": "^1.1.1"
+    "babel-preset-solid": "^1.1.1"
   },
   "devDependencies": {
     "@skypack/package-check": "^0.2.2",
     "@types/babel__core": "^7.1.15",
     "@types/node": "^16.7.4",
+    "esbuild": "^0.12.24",
     "del": "^6.0.0",
     "serve": "^12.0.0",
+    "solid-js": "^1.1.1",
     "typescript": "^4.4.2"
   }
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -13,5 +13,45 @@ build({
   target: "esnext",
   format: "esm",
   outfile: resolve(TESTS, "index.js"),
-  minify: true,
+  minify: process.env.NODE_ENV === 'production',
 }).catch(() => process.exit(1));
+build({
+  platform: 'node',
+  bundle: true,
+  entryPoints: [resolve(TESTS, "ssr.tsx")],
+  plugins: [solidPlugin({ generate: 'ssr' })],
+  target: "esnext",
+  format: "esm",
+  outfile: resolve(TESTS, "ssr.js"),
+  // external: [
+  //   "solid-js",
+  //   "solid-js/web"
+  // ],
+  minify: process.env.NODE_ENV === 'production',
+}).catch(() => process.exit(1));
+build({
+  platform: "browser",
+  bundle: true,
+  entryPoints: [resolve(TESTS, "index.tsx")],
+  plugins: [solidPlugin({ hydratable: true })],
+  target: "esnext",
+  format: "esm",
+  outfile: resolve(TESTS, "hydratable.js"),
+  minify: process.env.NODE_ENV === 'production',
+}).catch(() => process.exit(1));
+build({
+  platform: 'node',
+  bundle: true,
+  entryPoints: [resolve(TESTS, "ssr.tsx")],
+  plugins: [solidPlugin({ generate: 'ssr', hydratable: true })],
+  target: "esnext",
+  format: "esm",
+  // external: [
+  //   "solid-js",
+  //   "solid-js/web"
+  // ],
+  outfile: resolve(TESTS, "ssr-hydratable.js"),
+  minify: process.env.NODE_ENV === 'production',
+}).catch(() => process.exit(1));
+
+

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,7 +5,12 @@ import { transformAsync } from "@babel/core";
 import solid from "babel-preset-solid";
 import ts from "@babel/preset-typescript";
 
-export function solidPlugin(): Plugin {
+export interface SolidOptions {
+  hydratable?: boolean;
+  generate?: 'dom' | 'ssr';
+}
+
+export function solidPlugin(options: SolidOptions = {}): Plugin {
   return {
     name: "esbuild:solid",
 
@@ -17,7 +22,7 @@ export function solidPlugin(): Plugin {
         const filename = name + ext;
 
         const { code } = await transformAsync(source, {
-          presets: [solid, ts],
+          presets: [[solid, options], ts],
           filename,
           sourceMaps: "inline",
         });

--- a/tests/ssr.tsx
+++ b/tests/ssr.tsx
@@ -8,4 +8,4 @@ const App = () => {
   return <button onClick={[inc, 1]}>{count()}</button>;
 };
 
-renderToString(App, document.getElementById("app"));
+renderToString(App);

--- a/tests/ssr.tsx
+++ b/tests/ssr.tsx
@@ -1,0 +1,11 @@
+import { createSignal } from "solid-js";
+import { renderToString } from "solid-js/web";
+
+const App = () => {
+  const [count, setCount] = createSignal(0);
+  const inc = (by = 1) => setCount(count() + by);
+
+  return <button onClick={[inc, 1]}>{count()}</button>;
+};
+
+renderToString(App, document.getElementById("app"));


### PR DESCRIPTION
- Adds support for hydratable and ssr builds, basically just adds an options parameter to solid with similar field to that of `babel-preset-solid`.
- Moved `esbuild` and `solid-js` to `devDependencies`. Reason is that we just have to assume that the user of the plugin already has `esbuild` and `solid-js` installed.
- Added `ssr.tsx` for testing ssr builds.
- Added some test builds.

P.S. I don't have PNPM.