### PR TITLE
Support typescript's NodeNext moduleResoution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/types/plugin.d.ts",
       "default": "./dist/cjs/plugin.cjs",
       "node": "./dist/cjs/plugin.cjs",
       "import": "./dist/esm/plugin.mjs"


### PR DESCRIPTION
Adds `"types"` filed to `"exports"` in `package.json`

Otherwise this is happening:

![image](https://github.com/amoutonbrady/esbuild-plugin-solid/assets/24491503/49a78ac0-511c-42c3-8eb1-b841dc1134c4)
