### PR TITLE
feat: add `filter` option to customize targets to transform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import ts from "@babel/preset-typescript";
 
 /** Configuration options for esbuild-plugin-solid */
 export interface Options {
+  /** The filter to decide which files to transform @default /\.(t|j)sx$/ */
+  filter?: RegExp;
   /** The options to use for @babel/preset-typescript @default {} */
   typescript?: object;
   /**
@@ -93,7 +95,7 @@ export function solidPlugin(options?: Options): Plugin {
     name: "esbuild:solid",
 
     setup(build) {
-      build.onLoad({ filter: /\.(t|j)sx$/ }, async (args) => {
+      build.onLoad({ filter: options?.filter ?? /\.(t|j)sx$/ }, async (args) => {
         const source = await readFile(args.path, { encoding: "utf-8" });
 
         const { name, ext } = parse(args.path);


### PR DESCRIPTION
This lets users customize target files to transform. The most common use case would be applying the transform only for specific files in projects that contain JSX/TSX files targeting multiple frameworks (like [this](https://github.com/contents-technologies/stackflow/blob/a4ea37c7a32b3ab857d56bf133c8327644a61569/extensions/plugin-basic-ui/esbuild.config.js#L30))